### PR TITLE
Dockerfile: install cpp-coveralls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,10 @@ RUN apt-get update && \
     libcurl4-openssl-dev \
     dbus-x11 \
     python-yaml \
-    vim-common
+    vim-common \
+    python3-pip
+
+RUN pip3 install cpp-coveralls
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100
 RUN update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-6.0 100


### PR DESCRIPTION
The tpm2-tools CI needs cpp-coveralls installed to provide the coveralls
command.

Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>