### PR TITLE
Dockerfile: install dependencies for tpm2-pkcs11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,12 @@ RUN apt-get update && \
     libcurl4-openssl-dev \
     dbus-x11 \
     python-yaml \
+    python3-yaml \
     vim-common \
-    python3-pip
+    python3-pip \
+    libsqlite3-dev \
+    python-cryptography \
+    python3-cryptography
 
 RUN pip3 install cpp-coveralls
 


### PR DESCRIPTION
The [tpm2-pkcs11](https://github.com/tpm2-software/tpm2-pkcs11/) CI requires [SQLite3](https://github.com/tpm2-software/tpm2-pkcs11/blob/a32f9765afc9d9475ca9aa0968c1929f806bcbc2/configure.ac#L71) and the Python modules [PyYAML](https://github.com/tpm2-software/tpm2-pkcs11/blob/a32f9765afc9d9475ca9aa0968c1929f806bcbc2/tools/tpm2_pkcs11/tpm2.py#L9) and [cryptography](https://github.com/tpm2-software/tpm2-pkcs11/blob/a32f9765afc9d9475ca9aa0968c1929f806bcbc2/tools/tpm2_pkcs11/utils.py#L8), both for Python 2 and 3.