### PR TITLE
 Configure clang++ 6.0 using update-alternatives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && \
 RUN pip3 install cpp-coveralls
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100
+RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-6.0 100
 RUN update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-6.0 100
 
 ARG autoconf_archive=autoconf-archive-2018.03.13

--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ docker run --env /path/to/tpm2-tools/.ci/docker.env -v /path/to/tpm2-tools:/work
 
 ## Auto builds
 
-The repository is monitered by Docker Hub and the tpmsoftware/tpm2-tss image on
+The repository is monitored by Docker Hub and the [tpm2software/tpm2-tss](https://hub.docker.com/r/tpm2software/tpm2-tss) image on the
 Hub is rebuilt when the repository changes.


### PR DESCRIPTION
clang++ is required for [fuzzing of tpm2-tss](https://github.com/tpm2-software/tpm2-tss/blob/cdad427c9f38001ed432fb4324568d0c228436d9/Dockerfile#L57). This helps unifying the currently separate [tpm2-tss project Dockerfile](https://github.com/tpm2-software/tpm2-tss/blob/master/Dockerfile).

Additionally fix a typo and link to the Docker Hub image.