### PR TITLE
update to ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
This puts the build environment on OpenSSL 1.1.0 and it part of the post 4.0 tpm2-tools plan to remove ossl 1.0.1 support since it's end of life.

This needs to be merged with https://github.com/tpm2-software/tpm2-tools/pull/1720