### PR TITLE
Add swtpm and its dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,12 @@ RUN apt-get update && \
     python3-pip \
     libsqlite3-dev \
     python-cryptography \
-    python3-cryptography
+    python3-cryptography \
+    libtasn1-6-dev \
+    socat \
+    libseccomp-dev \
+    expect \
+    gawk
 
 RUN pip3 install cpp-coveralls
 
@@ -64,6 +69,20 @@ WORKDIR $ibmtpm_name/src
 RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
 && cp tpm_server /usr/local/bin
 RUN rm -fr $ibmtpm_name/src $ibmtpm_name.tar.gz
+
+WORKDIR /tmp
+RUN git clone https://github.com/stefanberger/libtpms.git
+RUN cd libtpms \
+	&& ./autogen.sh --prefix=/usr --with-openssl --with-tpm2 \
+	&& make -j$(nproc) \
+	&& make install
+
+WORKDIR /tmp
+RUN git clone https://github.com/stefanberger/swtpm.git
+RUN cd swtpm \
+	&& ./autogen.sh --prefix=/usr \
+	&& make -j$(nproc) \
+	&& make install || true
 
 ARG uthash="2.1.0"
 WORKDIR /tmp

--- a/fedora-30.docker
+++ b/fedora-30.docker
@@ -42,7 +42,12 @@ RUN yum -y install \
     procps \
     libasan \
     libubsan \
-    perl-Digest-SHA
+    perl-Digest-SHA \
+    libtasn1-devel \
+    socat \
+    libseccomp-devel \
+    expect \
+    gawk
 
 ARG autoconf_archive=autoconf-archive-2018.03.13
 WORKDIR /tmp
@@ -65,6 +70,20 @@ WORKDIR $ibmtpm_name/src
 RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
 && cp tpm_server /usr/local/bin
 RUN rm -fr $ibmtpm_name/src $ibmtpm_name.tar.gz
+
+WORKDIR /tmp
+RUN git clone https://github.com/stefanberger/libtpms.git
+RUN cd libtpms \
+	&& ./autogen.sh --prefix=/usr --with-openssl --with-tpm2 \
+	&& make -j$(nproc) \
+	&& make install
+
+WORKDIR /tmp
+RUN git clone https://github.com/stefanberger/swtpm.git
+RUN cd swtpm \
+	&& ./autogen.sh --prefix=/usr \
+	&& make -j$(nproc) \
+	&& make install
 
 ARG uthash="2.1.0"
 WORKDIR /tmp

--- a/opensuse-leap.docker
+++ b/opensuse-leap.docker
@@ -32,7 +32,13 @@ RUN zypper -n in \
     gzip \
     which \
     gcc-c++ \
-    iproute
+    iproute \
+    libtasn1-devel \
+    socat \
+    libseccomp-devel \
+    expect \
+    gawk \
+    net-tools-deprecated
 
 ARG autoconf_archive=autoconf-archive-2018.03.13
 WORKDIR /tmp
@@ -55,6 +61,20 @@ WORKDIR $ibmtpm_name/src
 RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
 && cp tpm_server /usr/local/bin
 RUN rm -fr $ibmtpm_name/src $ibmtpm_name.tar.gz
+
+WORKDIR /tmp
+RUN git clone https://github.com/stefanberger/libtpms.git
+RUN (cd libtpms \
+	&& ./autogen.sh --prefix=/usr --libdir=/usr/lib64 --with-openssl --with-tpm2 \
+	&& make -j$(nproc) \
+	&& make install)
+
+WORKDIR /tmp
+RUN git clone https://github.com/stefanberger/swtpm.git
+RUN cd swtpm \
+	&& ./autogen.sh --prefix=/usr \
+	&& make -j$(nproc) CFLAGS="-I/usr/include/libseccomp/" \
+	&& make install
 
 ARG uthash="2.1.0"
 WORKDIR /tmp

--- a/ubuntu-16.04.docker
+++ b/ubuntu-16.04.docker
@@ -35,7 +35,12 @@ RUN apt-get update && \
     python3-pip \
     libsqlite3-dev \
     python-cryptography \
-    python3-cryptography
+    python3-cryptography \
+    libtasn1-6-dev \
+    socat \
+    libseccomp-dev \
+    expect \
+    gawk
 
 RUN pip3 install cpp-coveralls
 
@@ -63,6 +68,20 @@ WORKDIR $ibmtpm_name/src
 RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
 && cp tpm_server /usr/local/bin
 RUN rm -fr $ibmtpm_name/src $ibmtpm_name.tar.gz
+
+WORKDIR /tmp
+RUN git clone https://github.com/stefanberger/libtpms.git
+RUN cd libtpms \
+	&& ./autogen.sh --prefix=/usr --with-openssl --with-tpm2 \
+	&& make -j$(nproc) \
+	&& make install
+
+WORKDIR /tmp
+RUN git clone https://github.com/stefanberger/swtpm.git
+RUN cd swtpm \
+	&& ./autogen.sh --prefix=/usr \
+	&& make -j$(nproc) \
+	&& make install
 
 ARG uthash="2.1.0"
 WORKDIR /tmp

--- a/ubuntu-18.04.docker
+++ b/ubuntu-18.04.docker
@@ -1,5 +1,6 @@
 FROM ubuntu:18.04
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y \
     autoconf-archive \
@@ -36,7 +37,12 @@ RUN apt-get update && \
     libsqlite3-dev \
     python-cryptography \
     python3-cryptography \
-    iproute2
+    iproute2 \
+    libtasn1-6-dev \
+    socat \
+    libseccomp-dev \
+    expect \
+    gawk
 
 RUN pip3 install cpp-coveralls
 
@@ -64,6 +70,20 @@ WORKDIR $ibmtpm_name/src
 RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
 && cp tpm_server /usr/local/bin
 RUN rm -fr $ibmtpm_name/src $ibmtpm_name.tar.gz
+
+WORKDIR /tmp
+RUN git clone https://github.com/stefanberger/libtpms.git
+RUN cd libtpms \
+	&& ./autogen.sh --prefix=/usr --with-openssl --with-tpm2 \
+	&& make -j$(nproc) \
+	&& make install
+
+WORKDIR /tmp
+RUN git clone https://github.com/stefanberger/swtpm.git
+RUN cd swtpm \
+	&& ./autogen.sh --prefix=/usr \
+	&& make -j$(nproc) \
+	&& make install
 
 ARG uthash="2.1.0"
 WORKDIR /tmp


### PR DESCRIPTION
The new TCTI `swtpm` requires the package swtpm. Add swtpm and its dependencies (e.g. libtpms).

See tpm2-software/tpm2-tss#1542
