### PR TITLE
docker: fix v1638 MSSIM available memory

### DIFF
--- a/fedora-30.docker
+++ b/fedora-30.docker
@@ -77,7 +77,8 @@ RUN wget --quiet --show-progress --progress=dot:giga "https://downloads.sourcefo
 	&& tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \
 	&& rm $ibmtpm_name.tar.gz
 WORKDIR $ibmtpm_name/src
-RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
+RUN sed -i 's/-DTPM_NUVOTON/-DTPM_NUVOTON $(CFLAGS)/' makefile
+RUN CFLAGS="-DNV_MEMORY_SIZE=32768 -DMIN_EVICT_OBJECTS=7" make -j$(nproc) \
 && cp tpm_server /usr/local/bin
 RUN rm -fr $ibmtpm_name/src $ibmtpm_name.tar.gz
 

--- a/fedora-32.docker
+++ b/fedora-32.docker
@@ -77,7 +77,8 @@ RUN wget --quiet --show-progress --progress=dot:giga "https://downloads.sourcefo
 	&& tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \
 	&& rm $ibmtpm_name.tar.gz
 WORKDIR $ibmtpm_name/src
-RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
+RUN sed -i 's/-DTPM_NUVOTON/-DTPM_NUVOTON $(CFLAGS)/' makefile
+RUN CFLAGS="-DNV_MEMORY_SIZE=32768 -DMIN_EVICT_OBJECTS=7" make -j$(nproc) \
 && cp tpm_server /usr/local/bin
 RUN rm -fr $ibmtpm_name/src $ibmtpm_name.tar.gz
 

--- a/opensuse-leap-15.2.docker
+++ b/opensuse-leap-15.2.docker
@@ -70,7 +70,8 @@ RUN wget --quiet --show-progress --progress=dot:giga "https://downloads.sourcefo
 	&& tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \
 	&& rm $ibmtpm_name.tar.gz
 WORKDIR $ibmtpm_name/src
-RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
+RUN sed -i 's/-DTPM_NUVOTON/-DTPM_NUVOTON $(CFLAGS)/' makefile
+RUN CFLAGS="-DNV_MEMORY_SIZE=32768 -DMIN_EVICT_OBJECTS=7" make -j$(nproc) \
 && cp tpm_server /usr/local/bin
 RUN rm -fr $ibmtpm_name/src $ibmtpm_name.tar.gz
 

--- a/opensuse-leap.docker
+++ b/opensuse-leap.docker
@@ -70,7 +70,8 @@ RUN wget --quiet --show-progress --progress=dot:giga "https://downloads.sourcefo
 	&& tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \
 	&& rm $ibmtpm_name.tar.gz
 WORKDIR $ibmtpm_name/src
-RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
+RUN sed -i 's/-DTPM_NUVOTON/-DTPM_NUVOTON $(CFLAGS)/' makefile
+RUN CFLAGS="-DNV_MEMORY_SIZE=32768 -DMIN_EVICT_OBJECTS=7" make -j$(nproc) \
 && cp tpm_server /usr/local/bin
 RUN rm -fr $ibmtpm_name/src $ibmtpm_name.tar.gz
 

--- a/ubuntu-16.04.docker
+++ b/ubuntu-16.04.docker
@@ -84,7 +84,8 @@ RUN wget --quiet --show-progress --progress=dot:giga "https://downloads.sourcefo
 	&& tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \
 	&& rm $ibmtpm_name.tar.gz
 WORKDIR $ibmtpm_name/src
-RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
+RUN sed -i 's/-DTPM_NUVOTON/-DTPM_NUVOTON $(CFLAGS)/' makefile
+RUN CFLAGS="-DNV_MEMORY_SIZE=32768 -DMIN_EVICT_OBJECTS=7" make -j$(nproc) \
 && cp tpm_server /usr/local/bin
 RUN rm -fr $ibmtpm_name/src $ibmtpm_name.tar.gz
 

--- a/ubuntu-18.04.docker
+++ b/ubuntu-18.04.docker
@@ -82,7 +82,8 @@ RUN wget --quiet --show-progress --progress=dot:giga "https://downloads.sourcefo
 	&& tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \
 	&& rm $ibmtpm_name.tar.gz
 WORKDIR $ibmtpm_name/src
-RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
+RUN sed -i 's/-DTPM_NUVOTON/-DTPM_NUVOTON $(CFLAGS)/' makefile
+RUN CFLAGS="-DNV_MEMORY_SIZE=32768 -DMIN_EVICT_OBJECTS=7" make -j$(nproc) \
 && cp tpm_server /usr/local/bin
 RUN rm -fr $ibmtpm_name/src $ibmtpm_name.tar.gz
 

--- a/ubuntu-20.04.docker
+++ b/ubuntu-20.04.docker
@@ -79,7 +79,8 @@ RUN wget --quiet --show-progress --progress=dot:giga "https://downloads.sourcefo
 	&& tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \
 	&& rm $ibmtpm_name.tar.gz
 WORKDIR $ibmtpm_name/src
-RUN CFLAGS="-I/usr/local/openssl/include" make -j$(nproc) \
+RUN sed -i 's/-DTPM_NUVOTON/-DTPM_NUVOTON $(CFLAGS)/' makefile
+RUN CFLAGS="-DNV_MEMORY_SIZE=32768 -DMIN_EVICT_OBJECTS=7" make -j$(nproc) \
 && cp tpm_server /usr/local/bin
 RUN rm -fr $ibmtpm_name/src $ibmtpm_name.tar.gz
 


### PR DESCRIPTION
See for details:
  - https://github.com/kgoldman/ibmswtpm2/pull/4

TL;DR the available version doesn't have enough memory with RSA
bumped to 3072 to be PC Client Spec compatible and it causes
issues with the RM.

Signed-off-by: William Roberts <william.c.roberts@intel.com>