### PR TITLE
Preparing CI for tpm2-tss w/ mbedTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ docker run -it <IMAGE ID> /bin/bash
 or to run the tpm2-tools CI sequence locally:
 
 ```
-docker run --env /path/to/tpm2-tools/.ci/docker.env -v /path/to/tpm2-tools:/workspace/tpm2-tools <IMAGE ID> /bin/bash -c '/workspace/tpm2-tools/.ci/docker.run'
+docker run --rm --env-file /path/to/tpm2-tools/.ci/docker.env -v /path/to/tpm2-tools:/workspace/tpm2-tools <IMAGE ID> /bin/bash -c '/workspace/tpm2-tools/.ci/docker.run'
+```
+
+or to run the tpm2-tss CI sequence locally
+
+```
+docker run --rm --env-file /path/to/tpm2-tss/.ci/docker.env -v /path/to/tpm2-tss:/workspace/tpm2-tss <IMAGE ID> /bin/bash -c '/workspace/tpm2-tss/.ci/docker.run'
 ```
 
 ## Auto builds

--- a/ubuntu-20.04.docker
+++ b/ubuntu-20.04.docker
@@ -50,6 +50,7 @@ RUN apt-get update && \
     libnss3-tools \
     python3-pip \
     libyaml-dev \
+    libmbedtls-dev \
     uuid-dev \
     opensc \
     gnutls-bin


### PR DESCRIPTION
I've added mbedTLS to the Ubuntu 20.04 image. This adds the possibility run all test cases with mbedTLS as crypto backend. I have intentionally not added mbedTLS to any of the other images, this allows us to test the build when mbedTLS is not present.

While tasting the changes locally, I noticed that the command line had `--env` instead of `--env-file`. I decided to fix in the same PR. But If requested, I can split it into a second PR.