### PR TITLE
Revert "Remove libgcrypt"

### DIFF
--- a/fedora-30.docker
+++ b/fedora-30.docker
@@ -18,6 +18,7 @@ RUN yum -y install \
     m4 \
     libtool \
     automake \
+    libgcrypt-devel \
     openssl-devel \
     gnulib \
     glib2-devel \

--- a/fedora-32.docker
+++ b/fedora-32.docker
@@ -18,6 +18,7 @@ RUN dnf -y install \
     m4 \
     libtool \
     automake \
+    libgcrypt-devel \
     openssl-devel \
     gnulib \
     glib2-devel \

--- a/opensuse-leap-15.2.docker
+++ b/opensuse-leap-15.2.docker
@@ -11,6 +11,7 @@ RUN zypper -n in \
     m4 \
     libtool \
     automake \
+    libgcrypt-devel \
     openssl-devel \
     glib2-devel \
     wget \

--- a/opensuse-leap.docker
+++ b/opensuse-leap.docker
@@ -11,6 +11,7 @@ RUN zypper -n in \
     m4 \
     libtool \
     automake \
+    libgcrypt-devel \
     openssl-devel \
     glib2-devel \
     wget \

--- a/ubuntu-16.04.docker
+++ b/ubuntu-16.04.docker
@@ -15,6 +15,7 @@ RUN apt-get update && \
     m4 \
     libtool \
     automake \
+    libgcrypt20-dev \
     libssl-dev \
     autoconf \
     gnulib \

--- a/ubuntu-18.04.docker
+++ b/ubuntu-18.04.docker
@@ -16,6 +16,7 @@ RUN apt-get update && \
     m4 \
     libtool \
     automake \
+    libgcrypt20-dev \
     libssl-dev \
     autoconf \
     gnulib \

--- a/ubuntu-20.04.docker
+++ b/ubuntu-20.04.docker
@@ -16,6 +16,7 @@ RUN apt-get update && \
     m4 \
     libtool \
     automake \
+    libgcrypt20-dev \
     libssl-dev \
     autoconf \
     gnulib \


### PR DESCRIPTION
When compining against tpm2-tss 2.4.x, this fails due to AM_PATH_LIBGCRYPT not found for all tpm2-tools things.

I think we need to keep libgcrypt in here, until we eol 2.4.x