### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
   [ pull_request, push ]
 jobs:
   publish-image:
-    name: Build and Push Docker image to GitHub Packages
+    name: Build Docker Images
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
+#
+# Build Docker Images for both pull_request and push operations
+#
 name: Build Status
 on:
-  push
+  [ pull_request, push ]
 jobs:
   publish-image:
     name: Build and Push Docker image to GitHub Packages
@@ -15,7 +18,6 @@ jobs:
           "ubuntu-20.04.arm32v7", "ubuntu-20.04.arm64v8",
           "fedora-32.ppc64le"
         ]
-    if: "github.repository_owner == 'tpm2-software'"
     steps:
       -
         name: Check out the repo
@@ -33,17 +35,9 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
-        name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-      -
-        name: Push to GitHub Packages
+        name: Build Docker Images
         uses: docker/build-push-action@v2
         with:
-          push: true
+          push: false
           context: .
           file: ./${{ matrix.distro }}.docker
-          tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.distro }}:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
       -
         name: Setup QEMU
         run: |
+          sudo apt-get update
           sudo apt-get install qemu binfmt-support qemu-user-static
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       -

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
           "ubuntu-20.04.arm32v7", "ubuntu-20.04.arm64v8",
           "fedora-32.ppc64le"
         ]
+    if: "github.repository_owner == 'tpm2-software'"
     steps:
       -
         name: Check out the repo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,10 @@
-name: PRQ Status
+#
+# We only publish docker files on a push AND if the tpm2-software is the org.
+# This way forks don't try to build AND publish
+#
+name: Publish
 on:
-  pull_request
+  push
 jobs:
   publish-image:
     name: Build and Push Docker image to GitHub Packages
@@ -15,6 +19,7 @@ jobs:
           "ubuntu-20.04.arm32v7", "ubuntu-20.04.arm64v8",
           "fedora-32.ppc64le"
         ]
+    if: "github.repository_owner == 'tpm2-software'"
     steps:
       -
         name: Check out the repo
@@ -32,9 +37,17 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
-        name: Build Docker Images
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Push to GitHub Packages
         uses: docker/build-push-action@v2
         with:
-          push: false
+          push: true
           context: .
           file: ./${{ matrix.distro }}.docker
+          tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.distro }}:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   push
 jobs:
   publish-image:
-    name: Build and Push Docker image to GitHub Packages
+    name: Publish Docker Images
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/pull_req.yml
+++ b/.github/workflows/pull_req.yml
@@ -1,0 +1,39 @@
+name: PRQ Status
+on:
+  pull_request
+jobs:
+  publish-image:
+    name: Build and Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [
+          "fedora-30", "fedora-32",
+          "opensuse-leap-15.2", "opensuse-leap",
+          "ubuntu-16.04", "ubuntu-18.04", "ubuntu-20.04",
+          "ubuntu-20.04.arm32v7", "ubuntu-20.04.arm64v8",
+          "fedora-32.ppc64le"
+        ]
+    steps:
+      -
+        name: Check out the repo
+        uses: actions/checkout@v2
+      -
+        name: Build the Dockerfiles
+        run: make -j $(nproc)
+      -
+        name: Setup QEMU
+        run: |
+          sudo apt-get install qemu binfmt-support qemu-user-static
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build Docker Images
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          context: .
+          file: ./${{ matrix.distro }}.docker

--- a/.github/workflows/pull_req.yml
+++ b/.github/workflows/pull_req.yml
@@ -25,6 +25,7 @@ jobs:
       -
         name: Setup QEMU
         run: |
+          sudo apt-get update
           sudo apt-get install qemu binfmt-support qemu-user-static
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       -

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SOURCE_SUFFIX := $(TARGET_SUFFIX).m4
 
 SOURCES := $(wildcard *$(SOURCE_SUFFIX))
 TARGETS := $(patsubst %$(SOURCE_SUFFIX),%$(TARGET_SUFFIX),$(SOURCES))
+MODULES := $(wildcard modules/*.m4)
 
 .PHONY: all
 all: $(TARGETS)
@@ -16,6 +17,7 @@ clean:
 debug:
 	@echo "SOURCES: $(SOURCES)"
 	@echo "TARGETS: $(TARGETS)"
+	@echo "MODULES: $(MODULES)"
 
-%$(TARGET_SUFFIX) : %$(SOURCE_SUFFIX)
+%$(TARGET_SUFFIX) : %$(SOURCE_SUFFIX) $(MODULES)
 	m4 -s -Imodules $< > $@

--- a/modules/ibmtpm1637.m4
+++ b/modules/ibmtpm1637.m4
@@ -1,6 +1,6 @@
 ARG ibmtpm_name=ibmtpm1637
 WORKDIR /tmp
-RUN wget --quiet --show-progress --progress=dot:giga "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz" \
+RUN wget -L --quiet --show-progress --progress=dot:giga "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz" \
 	&& sha256sum $ibmtpm_name.tar.gz | grep ^dd3a4c3f7724243bc9ebcd5c39bbf87b82c696d1c1241cb8e5883534f6e2e327 \
 	&& mkdir -p $ibmtpm_name \
 	&& tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \

--- a/modules/ibmtpm1637.m4
+++ b/modules/ibmtpm1637.m4
@@ -1,6 +1,6 @@
 ARG ibmtpm_name=ibmtpm1637
 WORKDIR /tmp
-RUN wget -L "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz"
+RUN wget $WGET_EXTRA_FLAGS -L "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz"
 RUN sha256sum $ibmtpm_name.tar.gz | grep ^dd3a4c3f7724243bc9ebcd5c39bbf87b82c696d1c1241cb8e5883534f6e2e327
 RUN mkdir -p $ibmtpm_name \
 	&& tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \

--- a/modules/ibmtpm1637.m4
+++ b/modules/ibmtpm1637.m4
@@ -1,8 +1,8 @@
 ARG ibmtpm_name=ibmtpm1637
 WORKDIR /tmp
-RUN wget -L --quiet --show-progress --progress=dot:giga "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz" \
-	&& sha256sum $ibmtpm_name.tar.gz | grep ^dd3a4c3f7724243bc9ebcd5c39bbf87b82c696d1c1241cb8e5883534f6e2e327 \
-	&& mkdir -p $ibmtpm_name \
+RUN wget -L "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz"
+RUN sha256sum $ibmtpm_name.tar.gz | grep ^dd3a4c3f7724243bc9ebcd5c39bbf87b82c696d1c1241cb8e5883534f6e2e327
+RUN mkdir -p $ibmtpm_name \
 	&& tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \
 	&& rm $ibmtpm_name.tar.gz
 WORKDIR $ibmtpm_name/src

--- a/modules/junit.m4
+++ b/modules/junit.m4
@@ -1,10 +1,10 @@
 ARG jver="4.13"
 WORKDIR /java
-RUN wget --quiet --show-progress --progress=dot:giga -O junit.jar "https://search.maven.org/remotecontent?filepath=junit/junit/4.13/junit-${jver}.jar"
+RUN wget $WGET_EXTRA_FLAGS -L -O junit.jar "https://search.maven.org/remotecontent?filepath=junit/junit/4.13/junit-${jver}.jar"
 
 ARG hver="2.2"
 WORKDIR /java
-RUN wget --quiet --show-progress --progress=dot:giga -O hamcrest.jar https://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest/${hver}/hamcrest-${hver}.jar
+RUN wget $WGET_EXTRA_FLAGS -L -O hamcrest.jar https://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest/${hver}/hamcrest-${hver}.jar
 
 ENV CLASSPATH=/java/hamcrest.jar:/java/junit.jar
 

--- a/modules/rust.m4
+++ b/modules/rust.m4
@@ -1,0 +1,5 @@
+# installs rust from source
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# $HOME doesn't expand, see https://github.com/moby/moby/issues/28971
+ENV PATH="/root/.cargo/bin:${PATH}"

--- a/modules/ubuntu_20.04_base_deps.m4
+++ b/modules/ubuntu_20.04_base_deps.m4
@@ -51,4 +51,5 @@ RUN apt-get update && \
     libmbedtls-dev \
     uuid-dev \
     opensc \
-    gnutls-bin
+    gnutls-bin \
+    rustc

--- a/modules/uthash.m4
+++ b/modules/uthash.m4
@@ -1,6 +1,6 @@
 ARG uthash="2.1.0"
 WORKDIR /tmp
-RUN wget --quiet --show-progress --progress=dot:giga "https://github.com/troydhanson/uthash/archive/v${uthash}.tar.gz" \
+RUN wget $WGET_EXTRA_FLAGS -L  "https://github.com/troydhanson/uthash/archive/v${uthash}.tar.gz" \
 	&& tar -xf v${uthash}.tar.gz \
         && cp uthash-${uthash}/src/*.h /usr/include/
 RUN rm -rf uthash-${uthash}/ v${uthash}.tar.gz

--- a/opensuse-leap-15.2.docker.m4
+++ b/opensuse-leap-15.2.docker.m4
@@ -55,6 +55,8 @@ RUN zypper -n in \
 include(`autoconf.m4')
 include(`python3.7.2.m4')
 
+include(`rust.m4')
+
 # Some other packages bring in python and python3, which at this time is too old, so we want
 # python3 to be the 3.7 version just installed.
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.7 0

--- a/opensuse-leap.docker.m4
+++ b/opensuse-leap.docker.m4
@@ -55,6 +55,8 @@ RUN zypper -n in \
 include(`autoconf.m4')
 include(`python3.7.2.m4')
 
+include(`rust.m4')
+
 # Some other packages bring in python and python3, which at this time is too old, so we want
 # python3 to be the 3.7 version just installed.
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.7 0

--- a/ubuntu-16.04.docker.m4
+++ b/ubuntu-16.04.docker.m4
@@ -45,7 +45,8 @@ RUN apt-get update && \
     sqlite3 \
     libnss3-tools \
     uuid-dev \
-    gnutls-bin
+    gnutls-bin \
+    rustc
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100
 RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-6.0 100

--- a/ubuntu-16.04.docker.m4
+++ b/ubuntu-16.04.docker.m4
@@ -57,6 +57,7 @@ include(`autoconf.m4')
 # We want python3.7 since tpm2-pkcs11 needs it, and other projects need a valid python
 include(`python3.7.2.m4')
 RUN update-alternatives --install /usr/local/bin/python3 python3 /usr/local/bin/python3.7 100
+RUN python3.7 -m pip install 'cryptography==3.2.1'
 RUN python3.7 -m pip install pyyaml cpp-coveralls pyasn1 pyasn1_modules python-pkcs11
 
 # there's a bug where old versions of libpkcs11 engine were install to the wrong directory, but
@@ -64,9 +65,9 @@ RUN python3.7 -m pip install pyyaml cpp-coveralls pyasn1 pyasn1_modules python-p
 RUN ln -s /usr/lib/ssl/engines/libpkcs11.so /usr/lib/x86_64-linux-gnu/openssl-1.0.0/engines/
 
 # Update automake to a non-broken AM_PYTHON_PATH checking version
-RUN wget http://mirrors.edge.kernel.org/ubuntu/pool/main/a/automake-1.16/automake_1.16.3-1ubuntu1_all.deb \
-    && sha256sum automake_1.16.3-1ubuntu1_all.deb | grep -q '^e73a9ad946973b45d9301bc86b4dd38d1875925c090bd53b975beccf7f5d2241' \
-    && dpkg -i automake_1.16.3-1ubuntu1_all.deb
+RUN wget http://http.us.debian.org/debian/pool/main/a/automake-1.16/automake_1.16.3-2_all.deb -O automake.deb \
+    && sha256sum automake.deb | grep -q '^720feb778ab6c33a28edf5815b747a7082b01ba358551cd35e99db8dfe73a136' \
+    && dpkg -i automake.deb
 
 
 include(`ibmtpm1637.m4')

--- a/ubuntu-18.04.docker.m4
+++ b/ubuntu-18.04.docker.m4
@@ -24,8 +24,8 @@ RUN apt-get update && \
     doxygen \
     libdbus-1-dev \
     libglib2.0-dev \
-    clang-6.0 \
-    clang-tools-6.0 \
+    clang-9 \
+    clang-tools-9 \
     pandoc \
     lcov \
     libcurl4-openssl-dev \
@@ -61,8 +61,8 @@ RUN pip3 install cpp-coveralls pyasn1 pyasn1_modules python-pkcs11
 RUN pip install --upgrade pyasn1-modules
 RUN pip3 install --upgrade pyasn1-modules
 
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100
-RUN update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-6.0 100
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 100
+RUN update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-9 100
 
 include(`pip3.m4')
 include(`autoconf.m4')

--- a/ubuntu-18.04.docker.m4
+++ b/ubuntu-18.04.docker.m4
@@ -54,7 +54,8 @@ RUN apt-get update && \
     libyaml-dev \
     uuid-dev \
     opensc \
-    gnutls-bin
+    gnutls-bin \
+    rustc
 
 RUN pip  install cpp-coveralls pyasn1 pyasn1_modules python-pkcs11
 RUN pip3 install cpp-coveralls pyasn1 pyasn1_modules python-pkcs11

--- a/ubuntu-20.04.arm32v7.docker.m4
+++ b/ubuntu-20.04.arm32v7.docker.m4
@@ -10,6 +10,8 @@ RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100
 RUN update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-10 100
 
 include(`autoconf.m4')
+
+ARG WGET_EXTRA_FLAGS="--no-check-certificate"
 include(`ibmtpm1637.m4')
 include(`swtpm.m4')
 include(`uthash.m4')


### PR DESCRIPTION
- Get the CI build stable
- Make clang-9 default on Ubuntu 16.04
- Separate publishing from building the containers. This will allow forks to test builds, as well as PRs to be built. Only on merge will the publish action happen to update the images.