### PR TITLE
github: add workflow_dispatch to actions config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@
 #
 name: Build Status
 on:
-  [ pull_request, push ]
+  [ pull_request, push, workflow_dispatch]
 jobs:
   publish-image:
     name: Build Docker Images

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@
 #
 name: Publish
 on:
-  push
+  [ push, workflow_dispatch]
 jobs:
   publish-image:
     name: Publish Docker Images


### PR DESCRIPTION
Allow jobs to be dispatched from manual triggers, see:
  - https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch

Signed-off-by: William Roberts <william.c.roberts@intel.com>