### PR TITLE
build: drop using CR_PAT and use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Push to GitHub Packages
         uses: docker/build-push-action@v2


### PR DESCRIPTION
Per:
  - https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry

Use GITHUB_TOKEN over a CR_PAT.

Signed-off-by: William Roberts <william.c.roberts@intel.com>