### PR TITLE
modules/ibmtpm1637: do not preserve owner when extracting the archive

### DIFF
--- a/modules/ibmtpm1637.m4
+++ b/modules/ibmtpm1637.m4
@@ -3,7 +3,7 @@ WORKDIR /tmp
 RUN wget $WGET_EXTRA_FLAGS -L "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz"
 RUN sha256sum $ibmtpm_name.tar.gz | grep ^dd3a4c3f7724243bc9ebcd5c39bbf87b82c696d1c1241cb8e5883534f6e2e327
 RUN mkdir -p $ibmtpm_name \
-	&& tar xvf $ibmtpm_name.tar.gz -C $ibmtpm_name \
+	&& tar xv --no-same-owner -f $ibmtpm_name.tar.gz -C $ibmtpm_name \
 	&& rm $ibmtpm_name.tar.gz
 WORKDIR $ibmtpm_name/src
 RUN sed -i 's/-DTPM_NUVOTON/-DTPM_NUVOTON $(CFLAGS)/' makefile


### PR DESCRIPTION
When extracting `ibmtpm1637.tar.gz` in a container created with Podman (using user namespaces), several errors occur such as:

    tar: ./LICENSE: Cannot change ownership to uid 339315, gid 578953: Invalid argument
    tar: ./ibmtpm.doc: Cannot change ownership to uid 339315, gid 578953: Invalid argument
    ...

Use option `--no-same-owner` (which is enabled by default for non-root users) in order to extract files without taking into account the owner given by the archive.