### PR TITLE
modules: merge RUN commands together

### DIFF
--- a/modules/autoconf.m4
+++ b/modules/autoconf.m4
@@ -1,10 +1,10 @@
 ARG autoconf_archive=autoconf-archive-2018.03.13
-WORKDIR /tmp
-RUN wget --quiet --show-progress --progress=dot:giga "http://mirror.kumi.systems/gnu/autoconf-archive/$autoconf_archive.tar.xz" \
-		&& tar -xf $autoconf_archive.tar.xz \
-        && rm $autoconf_archive.tar.xz \
-        && cd $autoconf_archive \
-        && ./configure --prefix=/usr \
-        && make -j $(nproc) && make install
-RUN rm -fr $autoconf_archive.tar.xz
+RUN cd /tmp \
+	&& wget --quiet --show-progress --progress=dot:giga "http://mirror.kumi.systems/gnu/autoconf-archive/$autoconf_archive.tar.xz" \
+	&& tar -xf $autoconf_archive.tar.xz \
+	&& rm $autoconf_archive.tar.xz \
+	&& cd $autoconf_archive \
+	&& ./configure --prefix=/usr \
+	&& make -j $(nproc) && make install \
+	&& rm -fr /tmp/$autoconf_archive.tar.xz /tmp/$autoconf_archive
 

--- a/modules/ibmtpm1637.m4
+++ b/modules/ibmtpm1637.m4
@@ -1,12 +1,12 @@
 ARG ibmtpm_name=ibmtpm1637
-WORKDIR /tmp
-RUN wget $WGET_EXTRA_FLAGS -L "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz"
-RUN sha256sum $ibmtpm_name.tar.gz | grep ^dd3a4c3f7724243bc9ebcd5c39bbf87b82c696d1c1241cb8e5883534f6e2e327
-RUN mkdir -p $ibmtpm_name \
+RUN cd /tmp \
+	&& wget $WGET_EXTRA_FLAGS -L "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz" \
+	&& sha256sum $ibmtpm_name.tar.gz | grep ^dd3a4c3f7724243bc9ebcd5c39bbf87b82c696d1c1241cb8e5883534f6e2e327 \
+	&& mkdir -p $ibmtpm_name \
 	&& tar xv --no-same-owner -f $ibmtpm_name.tar.gz -C $ibmtpm_name \
-	&& rm $ibmtpm_name.tar.gz
-WORKDIR $ibmtpm_name/src
-RUN sed -i 's/-DTPM_NUVOTON/-DTPM_NUVOTON $(CFLAGS)/' makefile
-RUN CFLAGS="-DNV_MEMORY_SIZE=32768 -DMIN_EVICT_OBJECTS=7" make -j$(nproc) \
-&& cp tpm_server /usr/local/bin
-RUN rm -fr $ibmtpm_name/src $ibmtpm_name.tar.gz
+	&& rm $ibmtpm_name.tar.gz \
+	&& cd $ibmtpm_name/src \
+	&& sed -i 's/-DTPM_NUVOTON/-DTPM_NUVOTON $(CFLAGS)/' makefile \
+	&& CFLAGS="-DNV_MEMORY_SIZE=32768 -DMIN_EVICT_OBJECTS=7" make -j$(nproc) \
+	&& cp tpm_server /usr/local/bin \
+	&& rm -fr /tmp/$ibmtpm_name

--- a/modules/junit.m4
+++ b/modules/junit.m4
@@ -1,10 +1,7 @@
 ARG jver="4.13"
-WORKDIR /java
-RUN wget $WGET_EXTRA_FLAGS -L -O junit.jar "https://search.maven.org/remotecontent?filepath=junit/junit/4.13/junit-${jver}.jar"
-
 ARG hver="2.2"
-WORKDIR /java
-RUN wget $WGET_EXTRA_FLAGS -L -O hamcrest.jar https://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest/${hver}/hamcrest-${hver}.jar
+RUN mkdir -p /java \
+	&& wget $WGET_EXTRA_FLAGS -L -O /java/junit.jar "https://search.maven.org/remotecontent?filepath=junit/junit/4.13/junit-${jver}.jar" \
+	&& wget $WGET_EXTRA_FLAGS -L -O /java/hamcrest.jar "https://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest/${hver}/hamcrest-${hver}.jar"
 
 ENV CLASSPATH=/java/hamcrest.jar:/java/junit.jar
-

--- a/modules/pip3.m4
+++ b/modules/pip3.m4
@@ -1,2 +1,2 @@
-RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install pyyaml cpp-coveralls pyasn1 pyasn1_modules python-pkcs11 cryptography bcrypt setuptools
+RUN python3 -m pip install --upgrade pip \
+	&& python3 -m pip install pyyaml cpp-coveralls pyasn1 pyasn1_modules python-pkcs11 cryptography bcrypt setuptools

--- a/modules/python3.7.2.m4
+++ b/modules/python3.7.2.m4
@@ -1,10 +1,12 @@
 ARG pyver="3.7.2"
-WORKDIR /tmp
-RUN wget --quiet --show-progress --progress=dot:giga "https://github.com/python/cpython/archive/v${pyver}.tar.gz" \
-	&& tar -xf v${pyver}.tar.gz
-RUN cd cpython-${pyver}/ \
+RUN cd /tmp \
+	&& wget --quiet --show-progress --progress=dot:giga "https://github.com/python/cpython/archive/v${pyver}.tar.gz" \
+	&& tar -xf v${pyver}.tar.gz \
+	&& cd cpython-${pyver}/ \
 	&& ./configure \
 	&& make -j$(nproc) \
-	&& make altinstall
+	&& make altinstall \
+	&& rm -fr /tmp/v${pyver}.tar.gz /tmp/cpython-${pyver}
+
 RUN update-alternatives --install "/usr/bin/python3" "python3" "$(which python3.7)" 100
-RUN update-alternatives --install "/usr/bin/"pip3 "pip3" "$(which pip3.7)" 100
+RUN update-alternatives --install "/usr/bin/pip3" "pip3" "$(which pip3.7)" 100

--- a/modules/swtpm.m4
+++ b/modules/swtpm.m4
@@ -1,13 +1,12 @@
-WORKDIR /tmp
-RUN git clone https://github.com/stefanberger/libtpms.git
-RUN cd libtpms \
+RUN git -C /tmp clone --depth=1 https://github.com/stefanberger/libtpms.git \
+	&& cd /tmp/libtpms \
 	&& ./autogen.sh --prefix=/usr $LIBTPMS_AUTOGEN_EXTRA --with-openssl --with-tpm2 \
 	&& make -j$(nproc) \
-	&& make install
-
-WORKDIR /tmp
-RUN git clone https://github.com/stefanberger/swtpm.git
-RUN cd swtpm \
+	&& make install \
+	&& rm -fr /tmp/libtpms \
+	&& git -C /tmp clone --depth=1 https://github.com/stefanberger/swtpm.git \
+	&& cd /tmp/swtpm \
 	&& ./autogen.sh --prefix=/usr \
 	&& make -j$(nproc) $SWTPM_MAKE_EXTRA \
-	&& make install
+	&& make install \
+	&& rm -fr /tmp/swtpm

--- a/modules/uthash.m4
+++ b/modules/uthash.m4
@@ -1,6 +1,6 @@
 ARG uthash="2.1.0"
-WORKDIR /tmp
-RUN wget $WGET_EXTRA_FLAGS -L  "https://github.com/troydhanson/uthash/archive/v${uthash}.tar.gz" \
+RUN cd /tmp \
+	&& wget $WGET_EXTRA_FLAGS -L  "https://github.com/troydhanson/uthash/archive/v${uthash}.tar.gz" \
 	&& tar -xf v${uthash}.tar.gz \
-        && cp uthash-${uthash}/src/*.h /usr/include/
-RUN rm -rf uthash-${uthash}/ v${uthash}.tar.gz
+	&& cp uthash-${uthash}/src/*.h /usr/include/ \
+	&& rm -fr /tmp/v${uthash}.tar.gz /tmp/uthash-${uthash}


### PR DESCRIPTION
Hello,
When building some images on a system with 60 GB free disk space, the build fails with "no space left on device". This is caused by the large number of layers which are created for each image.

Minimize the number of intermediate layers by combining all `RUN` statements together in each module, when this is appropriate.

Also use `cd ...` instead of `WORKDIR` statements to also reduce the number of intermediate layers.

With this, `podman build -f ./fedora-32.docker` succeeds on my test system which has "only" 60 GB free disk space.