### PR TITLE
RFC: add images with openssl3 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,8 @@ jobs:
           "opensuse-leap-15.2", "opensuse-leap",
           "ubuntu-18.04", "ubuntu-20.04",
           "ubuntu-20.04.arm32v7", "ubuntu-20.04.arm64v8",
-          "fedora-32.ppc64le"
+          "fedora-32.ppc64le",
+          "ubuntu-20.04-ossl3", "fedora-32-ossl3", "opensuse-leap-ossl3"
         ]
     steps:
       -

--- a/fedora-32-ossl3.docker.m4
+++ b/fedora-32-ossl3.docker.m4
@@ -1,0 +1,10 @@
+include(`fedora-32.docker.m4')
+
+# Install openssl3 and curl
+RUN dnf remove -y libssl-devel libcurl4-openssl-devel
+RUN dnf -y install \
+    perl-IPC-Cmd \
+    perl-Pod-Html
+include(`ossl3-curl.m4')
+
+WORKDIR /

--- a/modules/ossl3-curl.m4
+++ b/modules/ossl3-curl.m4
@@ -1,0 +1,29 @@
+## OpenSSL 3
+ENV OSSL_VERSION=3.0.0
+RUN realpath $(ldconfig -p \
+    | grep libcrypto.so.1| \
+    sed 's/.* \//\//')| \
+    sed 's/^\/usr\///'| \
+    sed 's/\/libcrypto.*//' > /tmp/libdir
+RUN wget --no-verbose https://www.openssl.org/source/openssl-$OSSL_VERSION.tar.gz
+RUN tar -zxf openssl-$OSSL_VERSION.tar.gz --one-top-level=/tmp/
+WORKDIR /tmp/openssl-$OSSL_VERSION
+RUN ./config --prefix=/usr \
+	&& make -j \
+	&& make LIBDIR=$(cat /tmp/libdir) install \
+	&& ldconfig
+# RUN rm /tpm/libdir
+# RUN rm -rfv /tmp/openssl-$OSSL_VERSION
+
+## CURL
+ENV CURL_VERSION=7.80.0
+RUN wget --no-verbose https://curl.se/download/curl-$CURL_VERSION.tar.gz
+RUN tar -zxf curl-$CURL_VERSION.tar.gz --one-top-level=/tmp/
+WORKDIR /tmp/curl-$CURL_VERSION
+RUN autoreconf -fi \
+	&& ./configure --libdir=/usr/$(cat /tmp/libdir) --prefix=/usr --with-openssl \
+ 	&& make -j \
+	&& make install \
+	&& ldconfig
+# RUN rm -rfv /tmp/$CURL_VERSION
+

--- a/opensuse-leap-ossl3.docker.m4
+++ b/opensuse-leap-ossl3.docker.m4
@@ -1,0 +1,7 @@
+include(`opensuse-leap.docker.m4')
+
+# Install openssl3 and curl
+RUN zypper remove -y libopenssl-devel libcurl-devel
+include(`ossl3-curl.m4')
+
+WORKDIR /

--- a/ubuntu-20.04-ossl3.docker.m4
+++ b/ubuntu-20.04-ossl3.docker.m4
@@ -1,0 +1,5 @@
+include(`ubuntu-20.04.docker.m4')
+RUN apt-get remove -y libssl-dev libcurl4-openssl-dev
+include(`ossl3-curl.m4')
+
+WORKDIR /


### PR DESCRIPTION
The dev packages for curl and openssl are removed and
openssl3 and curl compiled with openssl3 are installed.
Because this will only temporary used until ossl3 is available on
distributions this workaround was chosen, because no changes on
the other m4 files were needed.

Signed-off-by: Michael Eckel <michael.eckel@sit.fraunhofer.de>
Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>