### PR TITLE
images: add images with openssl3.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         distro: [
-          "fedora-30", "fedora-32", "fedora-34", "fedora-34-libressl",
-          "opensuse-leap-15.2", "opensuse-leap",
+          "fedora-30", "fedora-32", "fedora-32-ossl3", "fedora-34", "fedora-34-libressl",
+          "opensuse-leap-15.2", "opensuse-leap", "opensuse-leap-ossl3",
           "ubuntu-18.04", "ubuntu-20.04",
           "ubuntu-20.04.arm32v7", "ubuntu-20.04.arm64v8",
           "fedora-32.ppc64le",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         distro: [
-          "fedora-30", "fedora-32", "fedora-34", "fedora-34-libressl",
-          "opensuse-leap-15.2", "opensuse-leap",
+          "fedora-30", "fedora-32", "fedora-32-ossl3", "fedora-34", "fedora-34-libressl",
+          "opensuse-leap-15.2", "opensuse-leap", "opensuse-leap-ossl3",
           "ubuntu-18.04", "ubuntu-20.04",
           "ubuntu-20.04.arm32v7", "ubuntu-20.04.arm64v8",
           "fedora-32.ppc64le",

--- a/fedora-32-ossl3.docker.m4
+++ b/fedora-32-ossl3.docker.m4
@@ -1,0 +1,10 @@
+include(`fedora-32.docker.m4')
+
+# Install openssl3
+RUN dnf remove -y libssl-devel libcurl4-openssl-devel
+RUN dnf -y install \
+    perl-IPC-Cmd \
+    perl-Pod-Html
+include(`ossl3.m4')
+
+WORKDIR /

--- a/opensuse-leap-ossl3.docker.m4
+++ b/opensuse-leap-ossl3.docker.m4
@@ -1,0 +1,7 @@
+include(`opensuse-leap.docker.m4')
+
+# Install openssl3
+RUN zypper remove -y libopenssl-devel
+include(`ossl3.m4')
+
+WORKDIR /


### PR DESCRIPTION
The dev package of openssl is removed and openssl3 is compiled and installed.
Because this will only temporary used until ossl3 is available on
distributions this workaround was chosen, because no changes on
the other m4 files were needed.
The imagess ubuntu-20.04, fedora-32, and opensuse-leap were extended.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>