### PR TITLE
images: add alpine image with openssl3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           "ubuntu-18.04", "ubuntu-20.04",
           "ubuntu-20.04.arm32v7", "ubuntu-20.04.arm64v8",
           "fedora-32.ppc64le",
-          "alpine-3.15",
+          "alpine-3.15", "alpine-3.15-ossl3",
           "ubuntu-20.04-ossl3", "ubuntu-22.04", "ubuntu-22.04-mbedtls-3.1"
         ]
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
           "ubuntu-18.04", "ubuntu-20.04",
           "ubuntu-20.04.arm32v7", "ubuntu-20.04.arm64v8",
           "fedora-32.ppc64le",
-          "alpine-3.15",
+          "alpine-3.15", "alpine-3.15-ossl3",
           "ubuntu-20.04-ossl3", "ubuntu-22.04", "ubuntu-22.04-mbedtls-3.1"
         ]
     if: "github.repository_owner == 'tpm2-software'"

--- a/alpine-3.15-ossl3.docker.m4
+++ b/alpine-3.15-ossl3.docker.m4
@@ -1,0 +1,67 @@
+FROM alpine
+
+RUN apk update && \
+    apk upgrade && \
+    apk add \
+    autoconf-archive \
+    cmocka-dev \
+    net-tools \
+    make \
+    git \
+    gcc \
+    g++ \
+    m4 \
+    libtool \
+    automake \
+    autoconf \
+    wget \
+    doxygen \
+    dbus-dev \
+    glib-dev \
+    clang \
+    clang-analyzer \
+    clang-extra-tools \
+    json-c-dev  \
+    iproute2 \
+    coreutils \
+    uthash-dev \
+    python3-dev \
+    py3-yaml \
+    perl-utils \
+    openssl-dev \
+    acl \
+    xxd \
+    grep \
+    dbus \
+    vim \
+    dbus-x11 \
+    procps \
+    libtasn1-dev \
+    json-glib-dev \
+    gnutls-dev \
+    expect \
+    socat \
+    libseccomp-dev \
+    gawk \
+    gzip \
+    yaml-dev \
+    nss-tools \
+    opensc \
+    openjdk17-jdk \
+    openjdk17-jre
+
+include(`autoconf.m4')
+include(`ibmtpm1637.m4')
+
+RUN apk add 
+
+include(`swtpm.m4')
+RUN apk del openssl-dev
+RUN apk add openssl3-dev
+include(`curl-7.80.0.m4')
+RUN apk add openssl
+
+WORKDIR /
+
+
+    


### PR DESCRIPTION
After the installation of ossl3 with apk curl-dev can't be installed via apk.
Thus curl 7.80 has to be compiled.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>