### PR TITLE
images: add ubuntu22.04 with mbedtls 3.1.0.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           "ubuntu-20.04.arm32v7", "ubuntu-20.04.arm64v8",
           "fedora-32.ppc64le",
           "alpine-3.15",
-          "ubuntu-20.04-ossl3", "ubuntu-22.04"
+          "ubuntu-20.04-ossl3", "ubuntu-22.04", "ubuntu-22.04-mbedtls-3.1"
         ]
     steps:
       -

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           "ubuntu-20.04.arm32v7", "ubuntu-20.04.arm64v8",
           "fedora-32.ppc64le",
           "alpine-3.15",
-          "ubuntu-20.04-ossl3", "ubuntu-22.04"
+          "ubuntu-20.04-ossl3", "ubuntu-22.04", "ubuntu-22.04-mbedtls-3.1"
         ]
     if: "github.repository_owner == 'tpm2-software'"
     steps:

--- a/modules/mbedtls31.m4
+++ b/modules/mbedtls31.m4
@@ -1,0 +1,11 @@
+
+## MBEDTLS 3.1
+ENV MBEDTLS_VERSION=v3.1.0
+RUN wget --no-verbose https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/$MBEDTLS_VERSION.tar.gz
+RUN tar -zxf $MBEDTLS_VERSION.tar.gz --one-top-level=/tmp/
+RUN ls /tmp
+WORKDIR /tmp/mbedtls-3.1.0
+RUN make -j \
+	&& make -j \
+	&& make install \
+	&& ldconfig

--- a/ubuntu-22.04-mbedtls-3.1.docker.m4
+++ b/ubuntu-22.04-mbedtls-3.1.docker.m4
@@ -1,0 +1,65 @@
+FROM ubuntu:jammy
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y \
+    autoconf-archive \
+    curl \
+    libcmocka0 \
+    libcmocka-dev \
+    net-tools \
+    build-essential \
+    git \
+    pkg-config \
+    gcc \
+    g++ \
+    m4 \
+    libtool \
+    automake \
+    libgcrypt20-dev \
+    libssl-dev \
+    autoconf \
+    gnulib \
+    wget \
+    doxygen \
+    libdbus-1-dev \
+    libglib2.0-dev \
+    clang \
+    clang-tools \
+    pandoc \
+    lcov \
+    libcurl4-openssl-dev \
+    dbus-x11 \
+    vim-common \
+    libsqlite3-dev \
+    iproute2 \
+    libtasn1-6-dev \
+    socat \
+    libseccomp-dev \
+    expect \
+    gawk \
+    libjson-c-dev \
+    libengine-pkcs11-openssl \
+    default-jre \
+    default-jdk \
+    sqlite3 \
+    libnss3-tools \
+    python3 \
+    python3-pip \
+    libyaml-dev \
+    uuid-dev \
+    opensc \
+    gnutls-bin \
+    rustc \
+    acl \
+    libjson-glib-dev
+
+include(`pip3.m4')
+
+include(`autoconf.m4')
+include(`swtpm.m4')
+include(`uthash.m4')
+include(`junit.m4')
+include(`mbedtls31.m4')
+
+WORKDIR /


### PR DESCRIPTION
mbedtls version 3.1.0 from github will be compiled and installed.

Signed-off-by: Juergen Repp <juergen.repp@sit.fraunhofer.de>