### PR TITLE
modules: ensure that pip sees all dependencies

### DIFF
--- a/modules/pip3.m4
+++ b/modules/pip3.m4
@@ -1,8 +1,11 @@
+#
+# upgrade pip first so packages are not reinstalled using a version other than what may have been specified
+#
+RUN python3 -m pip install --upgrade pip
+# install everything in one shot so we don't get a newer version of a package we specified. Ie if a module has dep on cryptogtraphy
+# and we install it in different phases pip will upgrade cryptography
 RUN if [ -n "$PYCRYPTO_VERSION" ]; then \
-    python3 -m pip install cryptography==$PYCRYPTO_VERSION; \
+    python3 -m pip install cryptography==$PYCRYPTO_VERSION pyyaml cpp-coveralls pyasn1 pyasn1_modules python-pkcs11 bcrypt setuptools; \
 else \
-    python3 -m pip install cryptography; \
+    python3 -m pip install cryptography pyyaml cpp-coveralls pyasn1 pyasn1_modules python-pkcs11 bcrypt setuptools; \
 fi
-
-RUN python3 -m pip install --upgrade pip \
-	&& python3 -m pip install pyyaml cpp-coveralls pyasn1 pyasn1_modules python-pkcs11 bcrypt setuptools


### PR DESCRIPTION
When pinning a version with pip, if pip doesnt see all the installs at
once it tries to upgrade package versions even if they satisfy the
requirement. This causes issues since cryptograpy > 3.4.8 requires RUST
and some images don't have a new enough rust toolchain and thus the
wheel wont build. To fix this, run pip install and in one command with
all packages.

Signed-off-by: William Roberts <william.c.roberts@intel.com>