### PR TITLE
Add libusb-1.0-0-dev

### DIFF
--- a/alpine-3.15.docker.m4
+++ b/alpine-3.15.docker.m4
@@ -52,7 +52,7 @@ RUN apk update && \
     opensc \
     openjdk17-jdk \
     openjdk17-jre \
-    libusb-1.0-0-dev
+    libusb-dev
 
 include(`autoconf.m4')
 include(`ibmtpm1637.m4')

--- a/alpine-3.15.docker.m4
+++ b/alpine-3.15.docker.m4
@@ -51,7 +51,8 @@ RUN apk update && \
     nss-tools \
     opensc \
     openjdk17-jdk \
-    openjdk17-jre
+    openjdk17-jre \
+    libusb-1.0-0-dev
 
 include(`autoconf.m4')
 include(`ibmtpm1637.m4')

--- a/fedora-30.docker.m4
+++ b/fedora-30.docker.m4
@@ -57,7 +57,8 @@ RUN yum -y install \
     uuid-devel \
     python3-devel \
     acl \
-    json-glib-devel
+    json-glib-devel \
+    libusb-devel
 
 include(`pip3.m4')
 include(`autoconf.m4')

--- a/fedora-32.arm32v7.docker.m4
+++ b/fedora-32.arm32v7.docker.m4
@@ -57,7 +57,8 @@ RUN dnf -y install \
     libuuid-devel \
     python3-devel \
     openssl-pkcs11 \
-    acl
+    acl \
+    libusb-devel
 
 include(`pip3.m4')
 include(`autoconf.m4')

--- a/fedora-32.docker.m4
+++ b/fedora-32.docker.m4
@@ -59,7 +59,7 @@ RUN dnf -y install \
     openssl-pkcs11 \
     acl \
     json-glib-devel \
-    libusb-1.0-0-dev
+    libusb-devel
 
 include(`pip3.m4')
 include(`autoconf.m4')

--- a/fedora-32.docker.m4
+++ b/fedora-32.docker.m4
@@ -58,7 +58,8 @@ RUN dnf -y install \
     python3-devel \
     openssl-pkcs11 \
     acl \
-    json-glib-devel
+    json-glib-devel \
+    libusb-1.0-0-dev
 
 include(`pip3.m4')
 include(`autoconf.m4')

--- a/fedora-32.ppc64le.docker.m4
+++ b/fedora-32.ppc64le.docker.m4
@@ -59,7 +59,8 @@ RUN dnf -y install \
     openssl-pkcs11 \
     autoconf-archive \
     acl \
-    json-glib-devel
+    json-glib-devel \
+    libusb-devel
 
 # The last python cryptography version that allows no rust
 # per https://github.com/pyca/cryptography/blob/75be92de8e3bce9adcec42ef3967bed0d4500902/CHANGELOG.rst#3500---2021-09-29

--- a/fedora-34-libressl.docker.m4
+++ b/fedora-34-libressl.docker.m4
@@ -56,7 +56,8 @@ RUN dnf -y install \
     python3-devel \
     openssl-pkcs11 \
     acl \
-    json-glib-devel
+    json-glib-devel \
+    libusb-devel
 
 # make install goes into /usr/local/lib/pkgconfig which is non-standard
 # Set this so ./configure can find things and we don't have to worry about prefix changes

--- a/fedora-34.docker.m4
+++ b/fedora-34.docker.m4
@@ -59,7 +59,8 @@ RUN dnf -y install \
     python3-devel \
     openssl-pkcs11 \
     acl \
-    json-glib-devel
+    json-glib-devel \
+    libusb-devel
 
 include(`pip3.m4')
 include(`autoconf.m4')

--- a/modules/ubuntu_20.04_base_deps.m4
+++ b/modules/ubuntu_20.04_base_deps.m4
@@ -51,4 +51,5 @@ RUN apt-get update && \
     gnutls-bin \
     rustc \
     acl \
-    libjson-glib-dev
+    libjson-glib-dev \
+    libusb-1.0-0-dev

--- a/opensuse-leap-15.2.docker.m4
+++ b/opensuse-leap-15.2.docker.m4
@@ -51,7 +51,8 @@ RUN zypper -n in \
     acl \
     json-glib-devel \
     python \
-    python-pip
+    python-pip \
+    libusb-devel
 
 include(`autoconf.m4')
 include(`python3.7.2.m4')

--- a/opensuse-leap.docker.m4
+++ b/opensuse-leap.docker.m4
@@ -49,7 +49,8 @@ RUN zypper -n in \
     openssl-engine-libp11 \
     gnutls \
     acl \
-    json-glib-devel
+    json-glib-devel \
+    libusb-1.0-0-dev
 
 include(`autoconf.m4')
 include(`python3.7.2.m4')

--- a/opensuse-leap.docker.m4
+++ b/opensuse-leap.docker.m4
@@ -50,7 +50,7 @@ RUN zypper -n in \
     gnutls \
     acl \
     json-glib-devel \
-    libusb-1.0-0-dev
+    libusb-devel
 
 include(`autoconf.m4')
 include(`python3.7.2.m4')

--- a/ubuntu-18.04.docker.m4
+++ b/ubuntu-18.04.docker.m4
@@ -50,7 +50,8 @@ RUN apt-get update && \
     gnutls-bin \
     rustc \
     acl \
-    libjson-glib-dev
+    libjson-glib-dev \
+    libusb-1.0-0-dev
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 100
 RUN update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-9 100

--- a/ubuntu-22.04-mbedtls-3.1.docker.m4
+++ b/ubuntu-22.04-mbedtls-3.1.docker.m4
@@ -52,7 +52,8 @@ RUN apt-get update && \
     gnutls-bin \
     rustc \
     acl \
-    libjson-glib-dev
+    libjson-glib-dev \
+    libusb-1.0-0-dev
 
 include(`pip3.m4')
 

--- a/ubuntu-22.04.docker.m4
+++ b/ubuntu-22.04.docker.m4
@@ -53,7 +53,8 @@ RUN apt-get update && \
     gnutls-bin \
     rustc \
     acl \
-    libjson-glib-dev
+    libjson-glib-dev \
+    libusb-1.0-0-dev
 
 include(`pip3.m4')
 


### PR DESCRIPTION
This PR is associated with https://github.com/tpm2-software/tpm2-tss/pull/2479 to introduce a USB TPM (LetsTrust-TPM2Go) TCTI module. This PR alone may not suffice, please advise.

- alpine-3.15
- fedora-32
- opensuse-leap
- ubuntu-18.04
- ubuntu_20.04
- ubuntu-22.04
- ubuntu-22.04-mbedtls-3.1

Signed-off-by: wenxin.leong <wenxin.leong@infineon.com>