### PR TITLE
modules/pip3: allow pinning of bcrypt version

### DIFF
--- a/fedora-32.ppc64le.docker.m4
+++ b/fedora-32.ppc64le.docker.m4
@@ -66,6 +66,9 @@ RUN dnf -y install \
 # per https://github.com/pyca/cryptography/blob/75be92de8e3bce9adcec42ef3967bed0d4500902/CHANGELOG.rst#3500---2021-09-29
 ARG PYCRYPTO_VERSION="3.4.8"
 ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
+# bcrypt now needs rust to, avoid it
+# https://pypi.org/project/bcrypt/4.0.1/
+ARG PYBCRYPT_VERSION="3.2.2"
 include(`pip3.m4')
 include(`ibmtpm1637.m4')
 

--- a/modules/pip3.m4
+++ b/modules/pip3.m4
@@ -4,8 +4,7 @@
 RUN python3 -m pip install --upgrade pip
 # install everything in one shot so we don't get a newer version of a package we specified. Ie if a module has dep on cryptogtraphy
 # and we install it in different phases pip will upgrade cryptography
-RUN if [ -n "$PYCRYPTO_VERSION" ]; then \
-    python3 -m pip install cryptography==$PYCRYPTO_VERSION pyyaml cpp-coveralls pyasn1 pyasn1_modules python-pkcs11 bcrypt setuptools; \
-else \
-    python3 -m pip install cryptography pyyaml cpp-coveralls pyasn1 pyasn1_modules python-pkcs11 bcrypt setuptools; \
-fi
+RUN pkgs="cryptography==$PYCRYPTO_VERSION pyyaml cpp-coveralls pyasn1 pyasn1_modules python-pkcs11 \
+          bcrypt==$PYBCRYPT_VERSION setuptools"; \
+    pkgs=$(echo "$pkgs" | sed -E 's/==\s+/ /g'); \
+    python3 -m pip install $pkgs

--- a/ubuntu-20.04.arm32v7.docker.m4
+++ b/ubuntu-20.04.arm32v7.docker.m4
@@ -6,6 +6,9 @@ include(`ubuntu_20.04_base_deps.m4')
 # per https://github.com/pyca/cryptography/blob/75be92de8e3bce9adcec42ef3967bed0d4500902/CHANGELOG.rst#3500---2021-09-29
 ARG PYCRYPTO_VERSION="3.4.8"
 ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
+# bcrypt now needs rust to, avoid it
+# https://pypi.org/project/bcrypt/4.0.1/
+ARG PYBCRYPT_VERSION="3.2.2"
 include(`pip3.m4')
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100


### PR DESCRIPTION
bcrypt needs to be pinned for the following images:
  - fedora-32.ppc64le
  - ubuntu-20.04.arm32v7

This is due to Rust now being required since 4.0 of bcrypt per the CHANGELOG here:
  - https://pypi.org/project/bcrypt/4.0.1/

Thus pin it to the last pre 4.0 release of 3.2.2

Signed-off-by: William Roberts <william.c.roberts@intel.com>