### PR TITLE
Add libftdi-dev to all images

### DIFF
--- a/alpine-3.15.docker.m4
+++ b/alpine-3.15.docker.m4
@@ -55,7 +55,8 @@ RUN apk update && \
     opensc \
     openjdk17-jdk \
     openjdk17-jre \
-    libusb-dev
+    libusb-dev \
+    libftdi1-dev
 
 include(`autoconf.m4')
 include(`ibmtpm1637.m4')

--- a/fedora-32.docker.m4
+++ b/fedora-32.docker.m4
@@ -61,7 +61,8 @@ RUN dnf -y install \
     openssl-pkcs11 \
     acl \
     json-glib-devel \
-    libusb-devel
+    libusb-devel \
+    libftdi-devel
 
 include(`pip3.m4')
 include(`autoconf.m4')

--- a/fedora-32.ppc64le.docker.m4
+++ b/fedora-32.ppc64le.docker.m4
@@ -62,7 +62,8 @@ RUN dnf -y install \
     autoconf-archive \
     acl \
     json-glib-devel \
-    libusb-devel
+    libusb-devel \
+    libftdi-devel
 
 # The last python cryptography version that allows no rust
 # per https://github.com/pyca/cryptography/blob/75be92de8e3bce9adcec42ef3967bed0d4500902/CHANGELOG.rst#3500---2021-09-29

--- a/fedora-34-libressl.docker.m4
+++ b/fedora-34-libressl.docker.m4
@@ -59,7 +59,8 @@ RUN dnf -y install \
     openssl-pkcs11 \
     acl \
     json-glib-devel \
-    libusb-devel
+    libusb-devel \
+    libftdi-devel
 
 # make install goes into /usr/local/lib/pkgconfig which is non-standard
 # Set this so ./configure can find things and we don't have to worry about prefix changes

--- a/fedora-34.docker.m4
+++ b/fedora-34.docker.m4
@@ -62,7 +62,8 @@ RUN dnf -y install \
     openssl-pkcs11 \
     acl \
     json-glib-devel \
-    libusb-devel
+    libusb-devel \
+    libftdi-devel
 
 include(`pip3.m4')
 include(`autoconf.m4')

--- a/modules/ubuntu_20.04_base_deps.m4
+++ b/modules/ubuntu_20.04_base_deps.m4
@@ -52,4 +52,5 @@ RUN apt-get update && \
     rustc \
     acl \
     libjson-glib-dev \
-    libusb-1.0-0-dev
+    libusb-1.0-0-dev \
+    libftdi-dev

--- a/opensuse-leap-15.2.docker.m4
+++ b/opensuse-leap-15.2.docker.m4
@@ -54,7 +54,8 @@ RUN zypper -n in \
     json-glib-devel \
     python \
     python-pip \
-    libusb-devel
+    libusb-devel \
+    libftdi1-devel
 
 include(`autoconf.m4')
 include(`python3.7.2.m4')

--- a/opensuse-leap.docker.m4
+++ b/opensuse-leap.docker.m4
@@ -52,7 +52,8 @@ RUN zypper -n in \
     gnutls \
     acl \
     json-glib-devel \
-    libusb-devel
+    libusb-devel \
+    libftdi1-devel
 
 include(`autoconf.m4')
 include(`python3.7.2.m4')

--- a/ubuntu-18.04.docker.m4
+++ b/ubuntu-18.04.docker.m4
@@ -55,7 +55,8 @@ RUN apt-get update && \
     rustc \
     acl \
     libjson-glib-dev \
-    libusb-1.0-0-dev
+    libusb-1.0-0-dev \
+    libftdi-dev
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 100
 RUN update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-9 100

--- a/ubuntu-22.04-mbedtls-3.1.docker.m4
+++ b/ubuntu-22.04-mbedtls-3.1.docker.m4
@@ -55,7 +55,8 @@ RUN apt-get update && \
     rustc \
     acl \
     libjson-glib-dev \
-    libusb-1.0-0-dev
+    libusb-1.0-0-dev \
+    libftdi-dev
 
 include(`pip3.m4')
 

--- a/ubuntu-22.04.docker.m4
+++ b/ubuntu-22.04.docker.m4
@@ -56,7 +56,8 @@ RUN apt-get update && \
     rustc \
     acl \
     libjson-glib-dev \
-    libusb-1.0-0-dev
+    libusb-1.0-0-dev \
+    libftdi-dev
 
 include(`pip3.m4')
 


### PR DESCRIPTION
This PR is associated with https://github.com/tpm2-software/tpm2-tss/pull/2503 to introduce a USB TPM (FTDI MPSSE USB to SPI bridge) TCTI module.

The TCTI module supports both libftdi-dev (version 0.x) and libftdi1-dev (version 1.x). Depending on the distro, either of these library is installed.

Signed-off-by: wenxin.leong <wenxin.leong@infineon.com>