### PR TITLE
[GitHub Actions] Fix deprecated warnings and failures that may occur when pushing to GHCR.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       -
         name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Check Diff for Changes
         uses: technote-space/get-diff-action@v6
@@ -37,19 +37,16 @@ jobs:
         run: make -j $(nproc)
         if: env.GIT_DIFF
       -
-        name: Setup QEMU
-        run: |
-          sudo apt-get update
-          sudo apt-get install qemu binfmt-support qemu-user-static
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
         if: env.GIT_DIFF
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         if: env.GIT_DIFF
       -
         name: Build Docker Images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: false
           context: .

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -14,29 +14,26 @@ jobs:
     steps:
       -
         name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Build the Dockerfiles
         run: make -j $(nproc)
       -
-        name: Setup QEMU
-        run: |
-          sudo apt-get update
-          sudo apt-get install qemu binfmt-support qemu-user-static
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: USERNAME
           password: ${{ secrets.CR_PAT }}
       -
         name: Push to GitHub Packages
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           context: .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       -
         name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Check Diff for Changes
         uses: technote-space/get-diff-action@v6
@@ -39,19 +39,16 @@ jobs:
         run: make -j $(nproc)
         if: env.GIT_DIFF
       -
-        name: Setup QEMU
-        run: |
-          sudo apt-get update
-          sudo apt-get install qemu binfmt-support qemu-user-static
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
         if: env.GIT_DIFF
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         if: env.GIT_DIFF
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -59,7 +56,7 @@ jobs:
         if: env.GIT_DIFF
       -
         name: Push to GitHub Packages
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           context: .


### PR DESCRIPTION
By using the latest release of actions, the following issues can be addressed:

- Fix the warning "Node.js 12 actions are deprecated" which is triggered by actions/checkout@v2, docker/setup-buildx-action@v1, docker/login-action@v1, docker/build-push-action@v2.
- Fix a known stability issue ([#761](https://github.com/docker/build-push-action/issues/761)) that arises when pushing to GHCR. This issue has been resolved in the latest release. Changes have been made to follow the recommended sequence provided at https://github.com/marketplace/actions/build-and-push-docker-images. These changes are:
  1. Name: Set up QEMU.
     Uses: docker/setup-qemu-action@v2.
  2. Name: Set up Docker Buildx.
     Uses: docker/setup-buildx-action@v2.
  3. Name: Login to Docker Hub.
     Uses: docker/login-action@v2.
  4. Name: Build and push.
     Uses: docker/build-push-action@v4.