### PR TITLE
opensuse-leap: install gnutls from source to obtain the latest version

### DIFF
--- a/opensuse-leap.docker.m4
+++ b/opensuse-leap.docker.m4
@@ -49,11 +49,12 @@ RUN zypper -n in \
     patch \
     sqlite3 \
     openssl-engine-libp11 \
-    gnutls \
     acl \
     json-glib-devel \
     libusb-devel \
-    libftdi1-devel
+    libftdi1-devel \
+    libnettle-devel \
+    p11-kit-devel
 
 include(`autoconf.m4')
 include(`python3.7.2.m4')
@@ -80,5 +81,14 @@ include(`swtpm.m4')
 
 include(`uthash.m4')
 include(`junit.m4')
+
+# Install GnuTLS-3.8.3 from source
+RUN wget --no-verbose https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8/gnutls-3.8.3.tar.xz
+RUN tar -xf gnutls-3.8.3.tar.xz --one-top-level=/tmp/
+WORKDIR /tmp/gnutls-3.8.3
+RUN ./configure --with-included-unistring --disable-doc --disable-tests \
+        && make -j \
+        && make install \
+        && ldconfig
 
 WORKDIR /


### PR DESCRIPTION
 To resolve a known [issue](https://gitlab.com/gnutls/gnutls/-/issues/965) that leads to the failure of the [tpm2-pkcs11](https://github.com/tpm2-software/tpm2-pkcs11) CI, it's necessary to install GNUTLS from the source. This is because the ZYpp package manager does not offer the latest version of GNUTLS.