### PR TITLE
Correct a missing dependency in opensuse-leap >= 15.4

### DIFF
--- a/opensuse-leap.docker.m4
+++ b/opensuse-leap.docker.m4
@@ -54,7 +54,8 @@ RUN zypper -n in \
     libusb-devel \
     libftdi1-devel \
     libnettle-devel \
-    p11-kit-devel
+    p11-kit-devel \
+    openssh-common
 
 include(`autoconf.m4')
 include(`python3.7.2.m4')


### PR DESCRIPTION
GitHub Actions failed for https://github.com/tpm2-software/tpm2-pkcs11 due to the absence of the ssh-keygen binary.

The ssh-keygen binary is absent from opensuse-leap >= 15.4. In older versions, this binary was indirectly installed through a chain of packages: git -> git-core -> openssh-clients -> openssh-common. However, in later versions, git-core no longer installs openssh-clients. Therefore, we need to install openssh-common manually.