### PR TITLE
ubuntu22.04/24.04: add libtpms/swtpm

### DIFF
--- a/arch-linux.docker.m4
+++ b/arch-linux.docker.m4
@@ -27,6 +27,7 @@ RUN pacman -Sy --noconfirm \
     libltdl \
     libusb \
     libftdi \
+    ibm-sw-tpm2 \
     swtpm \
     pkgfile \
     glib2 \

--- a/fedora-34-libressl.docker.m4
+++ b/fedora-34-libressl.docker.m4
@@ -70,6 +70,7 @@ ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 include(`libressl.m4')
 include(`pip3.m4')
 include(`autoconf.m4')
+include(`ibmtpm1637.m4')
 include(`swtpm.m4')
 include(`uthash.m4')
 include(`junit.m4')

--- a/ubuntu-22.04-mbedtls-3.1.docker.m4
+++ b/ubuntu-22.04-mbedtls-3.1.docker.m4
@@ -62,6 +62,7 @@ RUN apt-get update && \
 include(`pip3.m4')
 
 include(`autoconf.m4')
+include(`ibmtpm1682.m4')
 include(`swtpm.m4')
 include(`uthash.m4')
 include(`junit.m4')

--- a/ubuntu-22.04-mbedtls-3.6.docker.m4
+++ b/ubuntu-22.04-mbedtls-3.6.docker.m4
@@ -61,6 +61,7 @@ RUN apt-get update && \
 include(`pip3.m4')
 
 include(`autoconf.m4')
+include(`ibmtpm1682.m4')
 include(`swtpm.m4')
 include(`uthash.m4')
 include(`junit.m4')

--- a/ubuntu-22.04.docker.m4
+++ b/ubuntu-22.04.docker.m4
@@ -58,24 +58,14 @@ RUN apt-get update && \
     libjson-glib-dev \
     libusb-1.0-0-dev \
     libftdi-dev \
+    libgmp-dev \
     uthash-dev
 
 include(`pip3.m4')
 
-ARG ibmtpm_name=ibmtpm1682
-RUN cd /tmp \
-        && wget $WGET_EXTRA_FLAGS -L "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz" \
-        && sha256sum $ibmtpm_name.tar.gz | grep ^3cb642f871a17b23d50b046e5f95f449c2287415fc1e7aeb4bdbb8920dbcb38f \
-        && mkdir -p $ibmtpm_name \
-        && tar xv --no-same-owner -f $ibmtpm_name.tar.gz -C $ibmtpm_name \
-        && rm $ibmtpm_name.tar.gz \
-        && cd $ibmtpm_name/src \
-        && sed -i 's/-DTPM_NUVOTON/-DTPM_NUVOTON $(CFLAGS)/' makefile \
-        && CFLAGS="-DNV_MEMORY_SIZE=32768 -DMIN_EVICT_OBJECTS=7" make -j$(nproc) \
-        && cp tpm_server /usr/local/bin \
-        && rm -fr /tmp/$ibmtpm_name
-
 include(`autoconf.m4')
+include(`ibmtpm1682.m4')
+include(`swtpm.m4')
 include(`junit.m4')
 
 WORKDIR /

--- a/ubuntu-24.04.docker.m4
+++ b/ubuntu-24.04.docker.m4
@@ -61,26 +61,16 @@ RUN apt-get update && \
     libjson-glib-dev \
     libusb-1.0-0-dev \
     libftdi-dev \
+    libgmp-dev \
     uthash-dev \
     clang-tidy \
     bear
 
 include(`pip3-withoutupgrade.m4')
 
-ARG ibmtpm_name=ibmtpm1682
-RUN cd /tmp \
-        && wget $WGET_EXTRA_FLAGS -L "https://downloads.sourceforge.net/project/ibmswtpm2/$ibmtpm_name.tar.gz" \
-        && sha256sum $ibmtpm_name.tar.gz | grep ^3cb642f871a17b23d50b046e5f95f449c2287415fc1e7aeb4bdbb8920dbcb38f \
-        && mkdir -p $ibmtpm_name \
-        && tar xv --no-same-owner -f $ibmtpm_name.tar.gz -C $ibmtpm_name \
-        && rm $ibmtpm_name.tar.gz \
-        && cd $ibmtpm_name/src \
-        && sed -i 's/-DTPM_NUVOTON/-DTPM_NUVOTON $(CFLAGS)/' makefile \
-        && CFLAGS="-DNV_MEMORY_SIZE=32768 -DMIN_EVICT_OBJECTS=7" make -j$(nproc) \
-        && cp tpm_server /usr/local/bin \
-        && rm -fr /tmp/$ibmtpm_name
-
 include(`autoconf.m4')
+include(`ibmtpm1682.m4')
+include(`swtpm.m4')
 include(`junit.m4')
 
 WORKDIR /


### PR DESCRIPTION
Swtpm was remove due to a bug (according to the commit message). We should not remove dependencies due to the test being broken. Instead, the downstream CI should select another test device (without the dependency being removed).

Add libtpms and swtpm back.

Actually, all platforms should have all TPM simulator options available. So also add ibmtpm to the platforms which do not have it, yet.