### PR TITLE
migrate from LABEL <key> <value> to <key>=<value>

### DIFF
--- a/alpine-3.15.docker.m4
+++ b/alpine-3.15.docker.m4
@@ -1,7 +1,7 @@
 # Alpine 3.15 Dockerfile
 FROM alpine:3.15
 
-LABEL org.opencontainers.image.source https://github.com/tpm2-software/tpm2-software-container
+LABEL org.opencontainers.image.source="https://github.com/tpm2-software/tpm2-software-container"
 
 RUN apk update && \
     apk upgrade && \

--- a/alpine-3.19.docker.m4
+++ b/alpine-3.19.docker.m4
@@ -1,7 +1,7 @@
 # Alpine 3.19 Dockerfile
 FROM alpine:3.19
 
-LABEL org.opencontainers.image.source https://github.com/tpm2-software/tpm2-software-container
+LABEL org.opencontainers.image.source="https://github.com/tpm2-software/tpm2-software-container"
 
 RUN apk update && \
     apk upgrade && \

--- a/fedora-32.ppc64le.docker.m4
+++ b/fedora-32.ppc64le.docker.m4
@@ -1,6 +1,6 @@
 FROM ppc64le/fedora:32
 
-LABEL org.opencontainers.image.source https://github.com/tpm2-software/tpm2-software-container
+LABEL org.opencontainers.image.source="https://github.com/tpm2-software/tpm2-software-container"
 
 # can return 100 if packages need update
 RUN dnf check-update; \

--- a/fedora-41.docker.m4
+++ b/fedora-41.docker.m4
@@ -1,6 +1,6 @@
 FROM fedora:41
 
-LABEL org.opencontainers.image.source https://github.com/tpm2-software/tpm2-software-container
+LABEL org.opencontainers.image.source="https://github.com/tpm2-software/tpm2-software-container"
 
 # can return 100 if packages need update
 RUN dnf check-update; \

--- a/fedora-43.docker.m4
+++ b/fedora-43.docker.m4
@@ -1,6 +1,6 @@
 FROM fedora:43
 
-LABEL org.opencontainers.image.source https://github.com/tpm2-software/tpm2-software-container
+LABEL org.opencontainers.image.source="https://github.com/tpm2-software/tpm2-software-container"
 
 # can return 100 if packages need update
 RUN dnf check-update; \

--- a/opensuse-leap-15.2.docker.m4
+++ b/opensuse-leap-15.2.docker.m4
@@ -1,6 +1,6 @@
 FROM opensuse/leap:15.2
 
-LABEL org.opencontainers.image.source https://github.com/tpm2-software/tpm2-software-container
+LABEL org.opencontainers.image.source="https://github.com/tpm2-software/tpm2-software-container"
 
 RUN zypper ref
 RUN zypper -n in \

--- a/opensuse-leap.docker.m4
+++ b/opensuse-leap.docker.m4
@@ -1,6 +1,6 @@
 FROM opensuse/leap
 
-LABEL org.opencontainers.image.source https://github.com/tpm2-software/tpm2-software-container
+LABEL org.opencontainers.image.source="https://github.com/tpm2-software/tpm2-software-container"
 
 RUN zypper ref
 RUN zypper -n in \

--- a/ubuntu-20.04.arm32v7.docker.m4
+++ b/ubuntu-20.04.arm32v7.docker.m4
@@ -1,6 +1,6 @@
 FROM arm32v7/ubuntu:20.04
 
-LABEL org.opencontainers.image.source https://github.com/tpm2-software/tpm2-software-container
+LABEL org.opencontainers.image.source="https://github.com/tpm2-software/tpm2-software-container"
 
 include(`ubuntu_20.04_base_deps.m4')
 

--- a/ubuntu-20.04.arm64v8.docker.m4
+++ b/ubuntu-20.04.arm64v8.docker.m4
@@ -1,6 +1,6 @@
 FROM arm64v8/ubuntu:20.04
 
-LABEL org.opencontainers.image.source https://github.com/tpm2-software/tpm2-software-container
+LABEL org.opencontainers.image.source="https://github.com/tpm2-software/tpm2-software-container"
 
 include(`ubuntu_20.04_base_deps.m4')
 include(`pip3.m4')

--- a/ubuntu-20.04.docker.m4
+++ b/ubuntu-20.04.docker.m4
@@ -1,7 +1,7 @@
 # Ubuntu 20.04 Dockerfile
 FROM ubuntu:20.04
 
-LABEL org.opencontainers.image.source https://github.com/tpm2-software/tpm2-software-container
+LABEL org.opencontainers.image.source="https://github.com/tpm2-software/tpm2-software-container"
 
 include(`ubuntu_20.04_base_deps.m4')
 

--- a/ubuntu-22.04-mbedtls-3.1.docker.m4
+++ b/ubuntu-22.04-mbedtls-3.1.docker.m4
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 
-LABEL org.opencontainers.image.source https://github.com/tpm2-software/tpm2-software-container
+LABEL org.opencontainers.image.source="https://github.com/tpm2-software/tpm2-software-container"
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \

--- a/ubuntu-22.04-mbedtls-3.6.docker.m4
+++ b/ubuntu-22.04-mbedtls-3.6.docker.m4
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 
-LABEL org.opencontainers.image.source https://github.com/tpm2-software/tpm2-software-container
+LABEL org.opencontainers.image.source="https://github.com/tpm2-software/tpm2-software-container"
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \

--- a/ubuntu-22.04.docker.m4
+++ b/ubuntu-22.04.docker.m4
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 
-LABEL org.opencontainers.image.source https://github.com/tpm2-software/tpm2-software-container
+LABEL org.opencontainers.image.source="https://github.com/tpm2-software/tpm2-software-container"
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \

--- a/ubuntu-24.04.docker.m4
+++ b/ubuntu-24.04.docker.m4
@@ -1,6 +1,6 @@
 FROM ubuntu:noble
 
-LABEL org.opencontainers.image.source https://github.com/tpm2-software/tpm2-software-container
+LABEL org.opencontainers.image.source="https://github.com/tpm2-software/tpm2-software-container"
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_REQUIRE_VIRTUALENV=0


### PR DESCRIPTION
The notation for docker image label has changed.
See https://docs.docker.com/reference/dockerfile/#label

This resulted in warnings:
> LegacyKeyValueFormat: "LABEL key=value" should be used instead of
>                       legacy "LABEL key value" format

Closes #97, rebased version of @joholl's original PR.